### PR TITLE
Add publish google workflow

### DIFF
--- a/.github/actions/Build.yml
+++ b/.github/actions/Build.yml
@@ -1,0 +1,61 @@
+name: "Build"
+description: "Build the project and run local tests"
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v3
+      shell: bash
+
+    - name: Copy CI gradle.properties
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+      shell: bash
+
+    # Local properties write in local.properties
+    - name: Setup local.properties
+      run: |
+        bash ./scripts/check_api_key.sh
+      shell: bash
+
+    # Decode keystore file encoded by base64
+    - name: Decode Keystore
+      run: |
+        echo ${{ secrets.KEYSTORE }} | base64 --d > keystore.jks
+      shell: bash
+
+    # Keystore properties write in keystore.properties
+    - name: Set up keystore.properties
+      run: |
+        echo "storePassword=${{ secrets.KEYSTORE_PASSWORD }}" >> keystore.properties
+        echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> keystore.properties
+        echo "keyAlias=${{ secrets.KEYSTORE_ALIAS }}" >> keystore.properties  
+        echo "storeFile=`pwd`/keystore.jks" >> ./keystore.properties
+      shell: bash
+
+    - name: Setup JDK 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu' # See 'Supported distributions' for available options
+        java-version: '17'
+      shell: bash
+
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v3
+      shell: bash
+
+    - name: Check spotless
+      run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
+      shell: bash
+
+    # Run tests build
+    - name: Run local tests
+      run: ./gradlew testDebugUnitTest --stacktrace
+      shell: bash
+
+    # Create APK and AAB
+    - name: Build all build type and flavor permutations
+      run: |
+        ./gradlew :app:assemble
+        ./gradlew :app:bundle
+      shell: bash

--- a/.github/actions/Build.yml
+++ b/.github/actions/Build.yml
@@ -33,6 +33,11 @@ runs:
         echo "storeFile=`pwd`/keystore.jks" >> ./keystore.properties
       shell: bash
 
+    - name: Set up service account key json
+      run: |
+        echo ${{ secrets.SERVICE_ACCOUNT_KEY_JSON }} | base64 --d > app/fireframe-service-account-key.json
+      shell: bash
+
     - name: Setup JDK 17
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,94 +1,94 @@
-# https://github.com/android/nowinandroid/blob/main/.github/workflows/Build.yaml
-
-name: Build
-
-env:
-  # The name of the main module repository
-  main_project_module: app
-
-  keystore_alias: ${{ secrets.KEYSTORE_ALIAS }}
-  keystore_password: ${{ secrets.KEYSTORE_PASSWORD }}
-  key_password: ${{ secrets.KEY_PASSWORD }}
-  encoded_keystore: ${{ secrets.KEYSTORE }}
-  open_weather_api_key: ${{ secrets.OPEN_WEATHER_API_KEY }}
-
-on:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-  # Allows you to run this workflow on push (merge into main) events
-  push:
-    branches:
-      - 'main'
-  # Triggers the workflow when a pull request is created
-  pull_request:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  test_and_apk:
-    name: "Local tests and APKs"
-    runs-on: ubuntu-latest
-
-    timeout-minutes: 60
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-
-      # Local properties write in local.properties
-      - name: Setup local.properties
-        run: |
-          bash ./scripts/check_api_key.sh
-
-      # Decode keystore file encoded by base64
-      - name: Decode Keystore
-        run: |
-          echo ${{ env.encoded_keystore }} | base64 --d > keystore.jks
-
-      # Keystore properties write in keystore.properties
-      - name: Set up keystore.properties
-        run: |
-          echo "storePassword=${{ env.keystore_password }}" >> keystore.properties
-          echo "keyPassword=${{ env.key_password }}" >> keystore.properties
-          echo "keyAlias=${{ env.keystore_alias }}" >> keystore.properties  
-          echo "storeFile=`pwd`/keystore.jks" >> ./keystore.properties
-
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-
-      - name: Check spotless
-        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
-
-      # Run tests build
-      - name: Run local tests
-        run: ./gradlew testDebugUnitTest --stacktrace
-
-      # Create APK and AAB
-      - name: Build all build type and flavor permutations
-        run: | 
-          ./gradlew :${{ env.main_project_module }}:assemble
-          ./gradlew :${{ env.main_project_module }}:bundle
-
-      # Upload build outputs (APKs and AABs)
-      - name: Upload build outputs
-        uses: actions/upload-artifact@v4
-        with:
-          name: APKs and AABs
-          path: | 
-            **/build/outputs/apk/**/*.apk
-            **/build/outputs/bundle/**/*.aab
-          retention-days: 1
+## https://github.com/android/nowinandroid/blob/main/.github/workflows/Build.yaml
+#
+#name: Build
+#
+#env:
+#  # The name of the main module repository
+#  main_project_module: app
+#
+#  keystore_alias: ${{ secrets.KEYSTORE_ALIAS }}
+#  keystore_password: ${{ secrets.KEYSTORE_PASSWORD }}
+#  key_password: ${{ secrets.KEY_PASSWORD }}
+#  encoded_keystore: ${{ secrets.KEYSTORE }}
+#  open_weather_api_key: ${{ secrets.OPEN_WEATHER_API_KEY }}
+#
+#on:
+#  # Allows you to run this workflow manually from the Actions tab
+#  workflow_dispatch:
+#  # Allows you to run this workflow on push (merge into main) events
+#  push:
+#    branches:
+#      - 'main'
+#  # Triggers the workflow when a pull request is created
+#  pull_request:
+#
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
+#
+#jobs:
+#  test_and_apk:
+#    name: "Local tests and APKs"
+#    runs-on: ubuntu-latest
+#
+#    timeout-minutes: 60
+#
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#
+#      - name: Validate Gradle Wrapper
+#        uses: gradle/wrapper-validation-action@v3
+#
+#      - name: Copy CI gradle.properties
+#        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+#
+#      # Local properties write in local.properties
+#      - name: Setup local.properties
+#        run: |
+#          bash ./scripts/check_api_key.sh
+#
+#      # Decode keystore file encoded by base64
+#      - name: Decode Keystore
+#        run: |
+#          echo ${{ env.encoded_keystore }} | base64 --d > keystore.jks
+#
+#      # Keystore properties write in keystore.properties
+#      - name: Set up keystore.properties
+#        run: |
+#          echo "storePassword=${{ env.keystore_password }}" >> keystore.properties
+#          echo "keyPassword=${{ env.key_password }}" >> keystore.properties
+#          echo "keyAlias=${{ env.keystore_alias }}" >> keystore.properties
+#          echo "storeFile=`pwd`/keystore.jks" >> ./keystore.properties
+#
+#      - name: Setup JDK 17
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: 'zulu' # See 'Supported distributions' for available options
+#          java-version: '17'
+#
+#      - name: Setup Gradle
+#        uses: gradle/gradle-build-action@v3
+#
+#      - name: Check spotless
+#        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
+#
+#      # Run tests build
+#      - name: Run local tests
+#        run: ./gradlew testDebugUnitTest --stacktrace
+#
+#      # Create APK and AAB
+#      - name: Build all build type and flavor permutations
+#        run: |
+#          ./gradlew :${{ env.main_project_module }}:assemble
+#          ./gradlew :${{ env.main_project_module }}:bundle
+#
+#      # Upload build outputs (APKs and AABs)
+#      - name: Upload build outputs
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: APKs and AABs
+#          path: |
+#            **/build/outputs/apk/**/*.apk
+#            **/build/outputs/bundle/**/*.aab
+#          retention-days: 1

--- a/.github/workflows/PublishGoogle.yml
+++ b/.github/workflows/PublishGoogle.yml
@@ -1,0 +1,35 @@
+name: PublishGoogle
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish_google:
+    name: "Publish Google Play"
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Build Action
+        uses: ./.github/actions/Build
+
+      # Upload build outputs (APKs and AABs)
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: APKs and AABs
+          path: |
+            **/build/outputs/apk/**/*.apk
+            **/build/outputs/bundle/**/*.aab
+            **/build/outputs/mapping/**/*.txt
+          retention-days: 1
+
+      # Publish build outputs (AAB) to Google Play
+      - name: Publish Google Play
+        run: |
+          echo "Publish Google Play"
+          ./gradlew publishReleaseBundle --artifact-dir app/build/outputs/bundle/release

--- a/.github/workflows/PublishGoogle.yml
+++ b/.github/workflows/PublishGoogle.yml
@@ -29,7 +29,6 @@ jobs:
           retention-days: 1
 
       # Publish build outputs (AAB) to Google Play
-      - name: Publish Google Play
+      - name: Publish Release Bundle
         run: |
-          echo "Publish Google Play"
           ./gradlew publishReleaseBundle --artifact-dir app/build/outputs/bundle/release

--- a/.github/workflows/Upload.yml
+++ b/.github/workflows/Upload.yml
@@ -1,0 +1,40 @@
+name: Upload
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Allows you to run this workflow on push (merge into main) events
+  push:
+    branches:
+      - 'main'
+  # Triggers the workflow when a pull request is created
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upload:
+    name: "Upload build outputs"
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Build Action
+        uses: ./.github/actions/Build
+
+      # Upload build outputs (APKs and AABs)
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: APKs and AABs
+          path: |
+            **/build/outputs/apk/**/*.apk
+            **/build/outputs/bundle/**/*.aab
+            **/build/outputs/mapping/**/*.txt
+          retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ bin/
 gen/
 out/
 build/
+
+# service account key json file
+fireframe-service-account-key.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,10 +81,9 @@ android {
     }
 }
 
-// TODO
-//play {
-//    serviceAccountCredentials.set(file("your-key.json"))
-//}
+play {
+    serviceAccountCredentials.set(rootProject.file("fireframe-service-account-key.json"))
+}
 
 dependencies {
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- GitHub Actionsのワークフロー「Build」を追加し、プロジェクトのビルドプロセスとローカルテストを自動化。
	- GitHub Actionsのワークフロー「Upload」を追加し、ビルド出力（APK、AAB、マッピングファイル）をアーティファクトにアップロードする機能を設定。
	- Google Playへのビルド出力（APKとAAB）の公開を自動化するワークフロー「PublishGoogle」を設定。

- **バグ修正**
	- `.gitignore`に`fireframe-service-account-key.json`を除外する行を追加。

- **ドキュメント**
	- `app/build.gradle.kts`ファイルで`serviceAccountCredentials`の設定パスを更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->