### PR TITLE
Fix design

### DIFF
--- a/app/src/test/java/com/tatsuki/fireframe/MainActivityTest.kt
+++ b/app/src/test/java/com/tatsuki/fireframe/MainActivityTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.tatsuki.fireframe.core.testing.util.HiltAndroidAutoInjectRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -19,7 +20,10 @@ import javax.inject.Inject
 
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(application = HiltTestApplication::class)
+@Config(
+    application = HiltTestApplication::class,
+    qualifiers = RobolectricDeviceQualifiers.MediumTablet,
+)
 @HiltAndroidTest
 class MainActivityTest {
 

--- a/core/designsystem/src/main/java/com/tatsuki/fireframe/core/designsystem/component/ConfirmDialog.kt
+++ b/core/designsystem/src/main/java/com/tatsuki/fireframe/core/designsystem/component/ConfirmDialog.kt
@@ -62,8 +62,7 @@ private fun ConfirmDialogContent(
                 Text(
                     text = title,
                     color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = MaterialTheme.typography.bodyLarge.fontSize,
-                    fontWeight = MaterialTheme.typography.bodyLarge.fontWeight,
+                    style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
@@ -75,14 +74,20 @@ private fun ConfirmDialogContent(
                         modifier = Modifier.weight(1f),
                         onClick = onDismissRequest,
                     ) {
-                        Text(text = negativeButtonText)
+                        Text(
+                            text = negativeButtonText,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
                     }
                     Spacer(modifier = Modifier.widthIn(16.dp))
                     Button(
                         modifier = Modifier.weight(1f),
                         onClick = onConfirmation,
                     ) {
-                        Text(text = positiveButtonText)
+                        Text(
+                            text = positiveButtonText,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
                     }
                 }
             }

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/HomeViewModel.kt
@@ -88,4 +88,4 @@ class HomeViewModel @Inject constructor(
     }
 }
 
-private const val MAX_SLIDE_GROUP_COUNT = 2
+private const val MAX_SLIDE_GROUP_COUNT = 10

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/HomeViewModel.kt
@@ -36,6 +36,7 @@ class HomeViewModel @Inject constructor(
             slideshowGroups = slideGroups,
             selectedSlideGroupId = selectedSlideGroupId,
             deleteTargetSlideGroup = deleteTargetSlideGroup,
+            isEnableSourceTypes = slideGroups.count() < MAX_SLIDE_GROUP_COUNT,
         )
     }
 
@@ -86,3 +87,5 @@ class HomeViewModel @Inject constructor(
         }
     }
 }
+
+private const val MAX_SLIDE_GROUP_COUNT = 2

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/model/HomeState.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/model/HomeState.kt
@@ -50,13 +50,14 @@ data class HomeState(
                 ),
             ),
             selectedSlideGroupId: Long = 1,
+            isEnableSourceTypes: Boolean = true,
         ): HomeState {
             return HomeState(
                 sourceTypes = sourceTypes,
                 slideshowGroups = slideGroups,
                 selectedSlideGroupId = selectedSlideGroupId,
                 deleteTargetSlideGroup = null,
-                isEnableSourceTypes = true,
+                isEnableSourceTypes = isEnableSourceTypes,
             )
         }
     }

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/model/HomeState.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/model/HomeState.kt
@@ -7,6 +7,7 @@ data class HomeState(
     val slideshowGroups: List<SlideGroup>,
     val selectedSlideGroupId: Long,
     val deleteTargetSlideGroup: SlideGroup?,
+    val isEnableSourceTypes: Boolean,
 ) {
 
     fun isSelectedAnySlideGroup(): Boolean {
@@ -24,6 +25,7 @@ data class HomeState(
                 slideshowGroups = emptyList(),
                 selectedSlideGroupId = -1L,
                 deleteTargetSlideGroup = null,
+                isEnableSourceTypes = true,
             )
         }
 
@@ -54,6 +56,7 @@ data class HomeState(
                 slideshowGroups = slideGroups,
                 selectedSlideGroupId = selectedSlideGroupId,
                 deleteTargetSlideGroup = null,
+                isEnableSourceTypes = true,
             )
         }
     }

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/model/HomeState.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/model/HomeState.kt
@@ -32,8 +32,6 @@ data class HomeState(
         fun fake(
             sourceTypes: List<SourceType> = listOf<SourceType>(
                 SourceType.LocalStorage(),
-                SourceType.LocalStorage(),
-                SourceType.LocalStorage(),
             ),
             slideGroups: List<SlideGroup> = listOf(
                 SlideGroup.fake(

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
@@ -31,11 +31,9 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tatsuki.fireframe.core.designsystem.component.ConfirmDialog
-import com.tatsuki.fireframe.core.designsystem.component.TopAppBar
 import com.tatsuki.fireframe.core.designsystem.theme.FireframeTheme
 import com.tatsuki.fireframe.core.model.SlideGroup
 import com.tatsuki.fireframe.feature.home.HomeViewModel
@@ -135,6 +133,7 @@ internal fun HomeScreen(
                             SourceTypeItem(
                                 sourceType = it,
                                 contentDescription = "SourceCategory",
+                                enable = homeState.isEnableSourceTypes,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .weight(1f),

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -101,8 +102,14 @@ internal fun HomeScreen(
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
-            TopAppBar(
-                title = stringResource(id = R.string.app_name),
+            Text(
+                text = stringResource(id = R.string.app_name),
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(vertical = 32.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.displaySmall,
+                fontFamily = FontFamily.Serif,
             )
             LazyColumn(
                 modifier = Modifier.padding(16.dp),
@@ -111,7 +118,7 @@ internal fun HomeScreen(
                     Text(
                         text = stringResource(id = R.string.select_image_label),
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 18.sp,
+                        style = MaterialTheme.typography.titleMedium,
                     )
                 }
                 item {
@@ -145,7 +152,7 @@ internal fun HomeScreen(
                     Text(
                         text = stringResource(id = R.string.slideshow_group_label),
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 18.sp,
+                        style = MaterialTheme.typography.titleMedium,
                     )
                 }
                 item {
@@ -226,6 +233,7 @@ private fun StartSlideshowButton(
             } else {
                 MaterialTheme.colorScheme.onSurface
             },
+            style = MaterialTheme.typography.bodyLarge,
         )
     }
 }

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
@@ -204,7 +204,8 @@ private fun StartSlideshowButton(
                 if (enable) {
                     MaterialTheme.colorScheme.primary
                 } else {
-                    MaterialTheme.colorScheme.surface
+                    MaterialTheme.colorScheme.onSurface
+                        .copy(alpha = 0.12f)
                 },
             )
             .clickable {
@@ -222,6 +223,7 @@ private fun StartSlideshowButton(
                 MaterialTheme.colorScheme.onPrimary
             } else {
                 MaterialTheme.colorScheme.onSurface
+                    .copy(alpha = 0.38f)
             },
         )
         Spacer(modifier = Modifier.width(4.dp))
@@ -231,6 +233,7 @@ private fun StartSlideshowButton(
                 MaterialTheme.colorScheme.onPrimary
             } else {
                 MaterialTheme.colorScheme.onSurface
+                    .copy(alpha = 0.38f)
             },
             style = MaterialTheme.typography.bodyLarge,
         )

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/HomeScreen.kt
@@ -107,7 +107,7 @@ internal fun HomeScreen(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(vertical = 32.dp),
-                color = MaterialTheme.colorScheme.onSurface,
+                color = MaterialTheme.colorScheme.primary,
                 style = MaterialTheme.typography.displaySmall,
                 fontFamily = FontFamily.Serif,
             )

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SlideGroupItem.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SlideGroupItem.kt
@@ -18,6 +18,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextOverflow.Companion
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.tatsuki.fireframe.core.model.SlideGroup
@@ -53,6 +55,8 @@ internal fun SlideGroupItem(
             Text(
                 text = slideGroup.groupName,
                 modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                 style = MaterialTheme.typography.bodyMedium,
             )

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SlideGroupItem.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SlideGroupItem.kt
@@ -17,9 +17,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.tatsuki.fireframe.core.model.SlideGroup
+import com.tatsuki.fireframe.feature.home.R
 
 @Composable
 internal fun SlideGroupItem(
@@ -52,14 +54,16 @@ internal fun SlideGroupItem(
                 text = slideGroup.groupName,
                 modifier = Modifier.weight(1f),
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
+                style = MaterialTheme.typography.bodyMedium,
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = "確認",
+                text = stringResource(id = R.string.confirm_button),
                 modifier = Modifier
                     .clickable { onOpenGroup(slideGroup) }
-                    .padding(4.dp),
+                    .padding(8.dp),
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
+                style = MaterialTheme.typography.bodyMedium,
             )
             Spacer(modifier = Modifier.width(8.dp))
             IconButton(

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SlideGroupItem.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SlideGroupItem.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.style.TextOverflow.Companion
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.tatsuki.fireframe.core.model.SlideGroup

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SourceTypeItem.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SourceTypeItem.kt
@@ -50,6 +50,7 @@ internal fun SourceTypeItem(
             Text(
                 text = stringResource(id = sourceType.nameResourceId),
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
+                style = MaterialTheme.typography.bodyMedium,
             )
         }
     }

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SourceTypeItem.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SourceTypeItem.kt
@@ -24,16 +24,22 @@ import com.tatsuki.fireframe.feature.home.model.SourceType
 internal fun SourceTypeItem(
     sourceType: SourceType,
     contentDescription: String,
+    enable: Boolean,
     modifier: Modifier = Modifier,
     onClick: (SourceType) -> Unit = { _ -> },
 ) {
     Card(
         modifier = modifier,
     ) {
-        Row(
-            modifier = Modifier
+        val clickableModifier = if (enable) {
+            Modifier
                 .fillMaxWidth()
                 .clickable { onClick(sourceType) }
+        } else {
+            Modifier.fillMaxWidth()
+        }
+        Row(
+            modifier = clickableModifier
                 .padding(
                     horizontal = 12.dp,
                     vertical = 20.dp,
@@ -44,12 +50,20 @@ internal fun SourceTypeItem(
             Icon(
                 painter = painterResource(id = sourceType.iconResourceId),
                 contentDescription = contentDescription,
-                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                tint = if (enable) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+                },
             )
             Spacer(modifier = Modifier.width(4.dp))
             Text(
                 text = stringResource(id = sourceType.nameResourceId),
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                color = if (enable) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                },
                 style = MaterialTheme.typography.bodyMedium,
             )
         }
@@ -58,9 +72,20 @@ internal fun SourceTypeItem(
 
 @Preview
 @Composable
-fun SourceTypeItemPreview() {
+fun SourceTypeItemEnablePreview() {
     SourceTypeItem(
         sourceType = SourceType.LocalStorage(),
         contentDescription = "LocalStorage",
+        enable = true,
+    )
+}
+
+@Preview
+@Composable
+fun SourceTypeItemDisablePreview() {
+    SourceTypeItem(
+        sourceType = SourceType.LocalStorage(),
+        contentDescription = "LocalStorage",
+        enable = false,
     )
 }

--- a/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SourceTypeItem.kt
+++ b/feature/home/src/main/java/com/tatsuki/fireframe/feature/home/ui/SourceTypeItem.kt
@@ -53,7 +53,7 @@ internal fun SourceTypeItem(
                 tint = if (enable) {
                     MaterialTheme.colorScheme.onPrimaryContainer
                 } else {
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                 },
             )
             Spacer(modifier = Modifier.width(4.dp))

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -3,9 +3,9 @@
     <string name="app_name">Fireframe</string>
     <string name="start_slideshow_button">スライドショー開始</string>
     <string name="select_image_label">画像選択</string>
-    <string name="slideshow_group_label">スライドセット</string>
+    <string name="slideshow_group_label">スライドグループ</string>
     <string name="local_storage_name">内部ストレージ</string>
-    <string name="slide_group_add_button_label">追加</string>
+    <string name="confirm_button">確認</string>
     <string name="delete_slide_group_confirm_dialog_title">%sを削除しますか？</string>
     <string name="delete_button">削除</string>
     <string name="cancel_button">キャンセル</string>

--- a/feature/home/src/test/java/com/tatsuki/fireframe/feature/home/HomeScreenshotTest.kt
+++ b/feature/home/src/test/java/com/tatsuki/fireframe/feature/home/HomeScreenshotTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.captureRoboImage
+import com.tatsuki.fireframe.core.model.SlideGroup
 import com.tatsuki.fireframe.feature.home.model.HomeState
 import com.tatsuki.fireframe.feature.home.ui.HomeScreen
 import org.junit.Rule
@@ -24,6 +25,41 @@ class HomeScreenshotTest {
         composeTestRule.setContent {
             HomeScreen(
                 homeState = HomeState.fake(),
+            )
+        }
+
+        composeTestRule
+            .onRoot()
+            .captureRoboImage()
+    }
+
+    @Test
+    fun capture_home_screen_disable_start_button_when_slide_group_empty() {
+        composeTestRule.setContent {
+            HomeScreen(
+                homeState = HomeState.fake(
+                    slideGroups = emptyList(),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onRoot()
+            .captureRoboImage()
+    }
+
+    @Test
+    fun capture_home_screen_disable_source_buttons_when_slide_group_max() {
+        composeTestRule.setContent {
+            HomeScreen(
+                homeState = HomeState.fake(
+                    slideGroups = (0..10).map {
+                        SlideGroup.fake(
+                            id = it.toLong(),
+                            groupName = "SlideGroup$it",
+                        )
+                    },
+                ),
             )
         }
 

--- a/feature/home/src/test/java/com/tatsuki/fireframe/feature/home/HomeScreenshotTest.kt
+++ b/feature/home/src/test/java/com/tatsuki/fireframe/feature/home/HomeScreenshotTest.kt
@@ -4,6 +4,7 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.tatsuki.fireframe.core.model.SlideGroup
 import com.tatsuki.fireframe.feature.home.model.HomeState
@@ -11,10 +12,12 @@ import com.tatsuki.fireframe.feature.home.ui.HomeScreen
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = RobolectricDeviceQualifiers.MediumTablet)
 class HomeScreenshotTest {
 
     @get:Rule
@@ -53,12 +56,13 @@ class HomeScreenshotTest {
         composeTestRule.setContent {
             HomeScreen(
                 homeState = HomeState.fake(
-                    slideGroups = (0..10).map {
+                    slideGroups = (1..11).map {
                         SlideGroup.fake(
                             id = it.toLong(),
                             groupName = "SlideGroup$it",
                         )
                     },
+                    isEnableSourceTypes = false,
                 ),
             )
         }

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/MediaSelectorViewModel.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/MediaSelectorViewModel.kt
@@ -21,14 +21,17 @@ class MediaSelectorViewModel @Inject constructor(
 
     private val mutableImageDirectories =
         MutableStateFlow(emptyList<SelectableLocalMediaDirectory>())
+    private val mutableIsEnableSaveButton = MutableStateFlow(false)
     private val mutableShouldShowConfirmDialog = MutableStateFlow(false)
 
     val mediaSelectorState = combine(
         mutableImageDirectories,
+        mutableIsEnableSaveButton,
         mutableShouldShowConfirmDialog,
-    ) { imageDirectories, shouldShowConfirmDialog ->
+    ) { imageDirectories, isEnableSaveButton, shouldShowConfirmDialog ->
         MediaSelectorState(
             selectableLocalMediaDirectories = imageDirectories,
+            isEnableSaveButton = isEnableSaveButton,
             shouldShowConfirmDialog = shouldShowConfirmDialog,
         )
     }
@@ -58,6 +61,13 @@ class MediaSelectorViewModel @Inject constructor(
                 image.isSelected.value = !image.isSelected.value
                 Log.d("MediaSelectorViewModel", "onSelect: $image")
             }
+        mutableIsEnableSaveButton.value = isEnableSaveButton()
+    }
+
+    private fun isEnableSaveButton(): Boolean {
+        return mutableImageDirectories.value
+            .flatMap { directory -> directory.selectableMediaImages }
+            .any { image -> image.isSelected.value }
     }
 
     fun onShowConfirmDialog() {

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/MediaSelectorViewModel.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/MediaSelectorViewModel.kt
@@ -54,7 +54,7 @@ class MediaSelectorViewModel @Inject constructor(
     }
 
     fun onSelect(selectableMediaImage: SelectableLocalMediaImage) {
-        if (isLimitSelectedImages()) return
+        if (isMaxSelectedImages()) return
         mutableImageDirectories.value
             .flatMap { directory -> directory.selectableMediaImages }
             .find { image -> image.id == selectableMediaImage.id }
@@ -65,7 +65,7 @@ class MediaSelectorViewModel @Inject constructor(
         mutableIsEnableSaveButton.value = isEnableSaveButton()
     }
 
-    private fun isLimitSelectedImages(): Boolean {
+    private fun isMaxSelectedImages(): Boolean {
         val isSelectedImages = mutableImageDirectories.value
             .flatMap { directory -> directory.selectableMediaImages }
             .filter { image -> image.isSelected.value }

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/MediaSelectorViewModel.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/MediaSelectorViewModel.kt
@@ -54,6 +54,7 @@ class MediaSelectorViewModel @Inject constructor(
     }
 
     fun onSelect(selectableMediaImage: SelectableLocalMediaImage) {
+        if (isLimitSelectedImages()) return
         mutableImageDirectories.value
             .flatMap { directory -> directory.selectableMediaImages }
             .find { image -> image.id == selectableMediaImage.id }
@@ -62,6 +63,13 @@ class MediaSelectorViewModel @Inject constructor(
                 Log.d("MediaSelectorViewModel", "onSelect: $image")
             }
         mutableIsEnableSaveButton.value = isEnableSaveButton()
+    }
+
+    private fun isLimitSelectedImages(): Boolean {
+        val isSelectedImages = mutableImageDirectories.value
+            .flatMap { directory -> directory.selectableMediaImages }
+            .filter { image -> image.isSelected.value }
+        return isSelectedImages.count() >= MAX_SELECTED_IMAGE_COUNT
     }
 
     private fun isEnableSaveButton(): Boolean {
@@ -97,3 +105,5 @@ class MediaSelectorViewModel @Inject constructor(
         }
     }
 }
+
+private const val MAX_SELECTED_IMAGE_COUNT = 25

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/model/MediaSelectorState.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/model/MediaSelectorState.kt
@@ -2,12 +2,14 @@ package com.tatsuki.fireframe.feature.mediaselector.model
 
 data class MediaSelectorState(
     val selectableLocalMediaDirectories: List<SelectableLocalMediaDirectory>,
+    val isEnableSaveButton: Boolean,
     val shouldShowConfirmDialog: Boolean,
 ) {
     companion object {
         fun create(): MediaSelectorState {
             return MediaSelectorState(
                 selectableLocalMediaDirectories = emptyList(),
+                isEnableSaveButton = false,
                 shouldShowConfirmDialog = false,
             )
         }
@@ -19,10 +21,12 @@ data class MediaSelectorState(
                         name = "FakeDirectory$it",
                     )
                 },
+            isEnableSaveButton: Boolean = false,
             shouldShowConfirmDialog: Boolean = false,
         ): MediaSelectorState {
             return MediaSelectorState(
                 selectableLocalMediaDirectories = selectableLocalMediaDirectories,
+                isEnableSaveButton = isEnableSaveButton,
                 shouldShowConfirmDialog = shouldShowConfirmDialog,
             )
         }

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/MediaSelectorScreen.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/MediaSelectorScreen.kt
@@ -134,14 +134,18 @@ internal fun MediaSelectorScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f))
+                .background(color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
                 .padding(16.dp),
         ) {
             Button(
-                modifier = Modifier.fillMaxWidth(),
                 onClick = onSave,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = mediaSelectorState.isEnableSaveButton,
             ) {
-                Text(text = stringResource(id = R.string.decide_button))
+                Text(
+                    text = stringResource(id = R.string.decide_button),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
         }
     }

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/SaveSlideGroupConfirmDialog.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/SaveSlideGroupConfirmDialog.kt
@@ -1,5 +1,6 @@
 package com.tatsuki.fireframe.feature.mediaselector.ui
 
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -14,7 +15,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text2.BasicTextField2
+import androidx.compose.foundation.text2.input.InputTransformation
 import androidx.compose.foundation.text2.input.TextFieldLineLimits
+import androidx.compose.foundation.text2.input.delete
 import androidx.compose.foundation.text2.input.rememberTextFieldState
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -86,6 +89,11 @@ private fun SaveSlideGroupConfirmDialogContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(8.dp),
+                        inputTransformation = { originalValue, valueWithChanges ->
+                            if (valueWithChanges.length > MAX_GROUP_NAME_LENGTH) {
+                                valueWithChanges.delete(MAX_GROUP_NAME_LENGTH, valueWithChanges.length)
+                            }
+                        },
                         textStyle = MaterialTheme.typography.bodyMedium.copy(
                             color = MaterialTheme.colorScheme.onSurface,
                         ),
@@ -125,6 +133,8 @@ private fun SaveSlideGroupConfirmDialogContent(
         },
     )
 }
+
+private const val MAX_GROUP_NAME_LENGTH = 15
 
 @Preview
 @Composable

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/SaveSlideGroupConfirmDialog.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/SaveSlideGroupConfirmDialog.kt
@@ -56,7 +56,7 @@ private fun SaveSlideGroupConfirmDialogContent(
     DialogBackground(
         content = {
             Column(
-                modifier = Modifier
+                modifier = modifier
                     .padding(16.dp),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -64,8 +64,7 @@ private fun SaveSlideGroupConfirmDialogContent(
                 Text(
                     text = stringResource(id = R.string.save_slide_group_confirm_dialog_message),
                     color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = MaterialTheme.typography.bodyLarge.fontSize,
-                    fontWeight = MaterialTheme.typography.bodyLarge.fontWeight,
+                    style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
@@ -87,7 +86,9 @@ private fun SaveSlideGroupConfirmDialogContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(8.dp),
-                        textStyle = MaterialTheme.typography.titleMedium,
+                        textStyle = MaterialTheme.typography.bodyMedium.copy(
+                            color = MaterialTheme.colorScheme.onSurface,
+                        ),
                         lineLimits = TextFieldLineLimits.SingleLine,
                     )
                 }
@@ -100,7 +101,10 @@ private fun SaveSlideGroupConfirmDialogContent(
                         modifier = Modifier
                             .weight(1f),
                     ) {
-                        Text(text = stringResource(id = R.string.cancel_button))
+                        Text(
+                            text = stringResource(id = R.string.cancel_button),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
                     }
                     Spacer(modifier = Modifier.widthIn(16.dp))
                     Button(
@@ -111,7 +115,10 @@ private fun SaveSlideGroupConfirmDialogContent(
                         modifier = Modifier.weight(1f),
                         enabled = textFieldState.text.isNotEmpty(),
                     ) {
-                        Text(text = stringResource(id = R.string.save_button))
+                        Text(
+                            text = stringResource(id = R.string.save_button),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
                     }
                 }
             }

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/SaveSlideGroupConfirmDialog.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/SaveSlideGroupConfirmDialog.kt
@@ -1,6 +1,5 @@
 package com.tatsuki.fireframe.feature.mediaselector.ui
 
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text2.BasicTextField2
-import androidx.compose.foundation.text2.input.InputTransformation
 import androidx.compose.foundation.text2.input.TextFieldLineLimits
 import androidx.compose.foundation.text2.input.delete
 import androidx.compose.foundation.text2.input.rememberTextFieldState

--- a/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/component/MediaImageItem.kt
+++ b/feature/mediaselector/src/main/java/com/tatsuki/fireframe/feature/mediaselector/ui/component/MediaImageItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,6 +63,7 @@ internal fun MediaImageItem(
                     .sizeIn(minWidth = 24.dp, maxWidth = 48.dp)
                     .padding(4.dp)
                     .align(Alignment.TopEnd),
+                tint = MaterialTheme.colorScheme.inversePrimary,
             )
         }
     }

--- a/feature/slideshow/src/main/java/com/tatsuki/fireframe/feature/slideshow/ui/SlideshowScreen.kt
+++ b/feature/slideshow/src/main/java/com/tatsuki/fireframe/feature/slideshow/ui/SlideshowScreen.kt
@@ -1,5 +1,6 @@
 package com.tatsuki.fireframe.feature.slideshow.ui
 
+import android.graphics.Color
 import android.graphics.Typeface
 import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -11,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
@@ -173,7 +172,7 @@ private fun DateInfoShortPanel(
         }
         TextClock(
             modifier = Modifier,
-            textColorResource = LocalContentColor.current.toArgb(),
+            textColorResource = Color.WHITE,
             textSize = 80f,
             typefaceStyle = Typeface.DEFAULT_BOLD,
         )

--- a/feature/slideshow/src/main/java/com/tatsuki/fireframe/feature/slideshow/ui/SlideshowScreen.kt
+++ b/feature/slideshow/src/main/java/com/tatsuki/fireframe/feature/slideshow/ui/SlideshowScreen.kt
@@ -167,6 +167,7 @@ private fun DateInfoShortPanel(
 
             DateText(
                 modifier = baseModifier,
+                color = androidx.compose.ui.graphics.Color.White,
                 fontSize = 24.sp,
             )
         }

--- a/feature/slideshow/src/test/java/com/tatsuki/fireframe/feature/slideshow/SlideshowScreenshotTest.kt
+++ b/feature/slideshow/src/test/java/com/tatsuki/fireframe/feature/slideshow/SlideshowScreenshotTest.kt
@@ -4,16 +4,19 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.tatsuki.fireframe.feature.slideshow.model.SlideshowState
 import com.tatsuki.fireframe.feature.slideshow.ui.SlideshowScreen
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = RobolectricDeviceQualifiers.MediumTablet)
 class SlideshowScreenshotTest {
 
     @get:Rule


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - ホーム画面において、ソースタイプの有効化/無効化を切り替える機能を追加しました。
  - メディアセレクター画面に保存ボタンの有効化/無効化を切り替える機能を追加しました。

- **スタイル**
  - 各種ボタンやテキストのスタイルを統一し、`MaterialTheme.typography`を使用するように変更しました。

- **バグ修正**
  - スライドグループが空の場合に開始ボタンを無効にするテストを追加しました。
  - スライドグループが最大数に達した場合にソースボタンを無効にするテストを追加しました。

- **UI 改善**
  - ホーム画面とメディアセレクター画面のボタンやテキストのデザインを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->